### PR TITLE
chore: update import from `@noir-lang/aztec_backend`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aztec/barretenberg": "file:../aztec-connect",
-        "@noir-lang/aztec_backend": "github:kobyhallx/aztec-backend#2bdf900c96af4895815253d00b9a25f7f55b1b15",
+        "@noir-lang/aztec_backend": "github:kobyhallx/aztec-backend#8e7a924dc827683d254ef4013ba8517ebe967dbb",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3127,9 +3127,9 @@
       }
     },
     "node_modules/@noir-lang/aztec_backend": {
-      "version": "0.1.0-8dc1057",
-      "resolved": "git+ssh://git@github.com/kobyhallx/aztec-backend.git#2bdf900c96af4895815253d00b9a25f7f55b1b15",
-      "integrity": "sha512-9s9hCvZ+YG4IYVdL2EpebSpeUNYbUEjc3dS/NNCNxGdwnkiWWkEVExrjvHvuNoXRDKYhrhQtXS7e35mw42lAsA=="
+      "version": "0.1.0-28014d8",
+      "resolved": "git+ssh://git@github.com/kobyhallx/aztec-backend.git#8e7a924dc827683d254ef4013ba8517ebe967dbb",
+      "integrity": "sha512-oDrOp+mZayN3IMww4sp+o4Dp5Gm7YB1/EkopF5Xz5JmpDjeCorzd+LG4oJmpdof4wgsQ6F7xuVKGHWqBjgfdrw=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",
@@ -19491,9 +19491,9 @@
       }
     },
     "@noir-lang/aztec_backend": {
-      "version": "git+ssh://git@github.com/kobyhallx/aztec-backend.git#2bdf900c96af4895815253d00b9a25f7f55b1b15",
-      "integrity": "sha512-9s9hCvZ+YG4IYVdL2EpebSpeUNYbUEjc3dS/NNCNxGdwnkiWWkEVExrjvHvuNoXRDKYhrhQtXS7e35mw42lAsA==",
-      "from": "@noir-lang/aztec_backend@github:kobyhallx/aztec-backend#2bdf900c96af4895815253d00b9a25f7f55b1b15"
+      "version": "git+ssh://git@github.com/kobyhallx/aztec-backend.git#8e7a924dc827683d254ef4013ba8517ebe967dbb",
+      "integrity": "sha512-oDrOp+mZayN3IMww4sp+o4Dp5Gm7YB1/EkopF5Xz5JmpDjeCorzd+LG4oJmpdof4wgsQ6F7xuVKGHWqBjgfdrw==",
+      "from": "@noir-lang/aztec_backend@github:kobyhallx/aztec-backend#8e7a924dc827683d254ef4013ba8517ebe967dbb"
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.10",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@aztec/barretenberg": "file:../aztec-connect",
-    "@noir-lang/aztec_backend": "github:kobyhallx/aztec-backend#2bdf900c96af4895815253d00b9a25f7f55b1b15",
+    "@noir-lang/aztec_backend": "github:kobyhallx/aztec-backend#8e7a924dc827683d254ef4013ba8517ebe967dbb",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import { enableLogs } from '@aztec/barretenberg/log';
 import {
   setupTurboProverAndVerifier
 } from "@aztec/barretenberg";
-import initAztecBackend, { serialise_acir_to_barrtenberg_circuit } from '@noir-lang/aztec_backend';
+import initAztecBackend, { serialize_acir_to_barretenberg_circuit } from '@noir-lang/aztec_backend';
 
 
 import './App.css';
@@ -26,7 +26,7 @@ function App() {
         let acir_bytes = new Uint8Array(Buffer.from(circuitJson.circuit, "hex"));
 
         await initAztecBackend();
-        const serializedCircuit = serialise_acir_to_barrtenberg_circuit(acir_bytes);
+        const serializedCircuit = serialize_acir_to_barretenberg_circuit(acir_bytes);
 
         const pk_arrayBuffer = await fetch(new URL('../circuit/target/circuit.pk', import.meta.url)).then(r => r.blob()).then(pk_blob => pk_blob.arrayBuffer());
         const vk_arraybuffer = await fetch(new URL('../circuit/target/circuit.vk', import.meta.url)).then(r => r.blob()).then(vk_blob => vk_blob.arrayBuffer());


### PR DESCRIPTION
This PR updates the imports to match those from https://github.com/noir-lang/aztec_backend.

Draft as kobyhallx/aztec_backend needs to be updated to expose this (and can then update dep).